### PR TITLE
Bam folder

### DIFF
--- a/Toy_example/input_bams.txt
+++ b/Toy_example/input_bams.txt
@@ -1,0 +1,9 @@
+/Users/user/Documents/GitHub/HCMM_CNVs_wrapper/Toy_example/CCLE_demo_S1.mini.bam
+/Users/user/Documents/GitHub/HCMM_CNVs_wrapper/Toy_example/CCLE_demo_S2.mini.bam
+/Users/user/Documents/GitHub/HCMM_CNVs_wrapper/Toy_example/CCLE_demo_S3.mini.bam
+/Users/user/Documents/GitHub/HCMM_CNVs_wrapper/Toy_example/CCLE_demo_S4.mini.bam
+/Users/user/Documents/GitHub/HCMM_CNVs_wrapper/Toy_example/CCLE_demo_S5.mini.bam
+/Users/user/Documents/GitHub/HCMM_CNVs_wrapper/Toy_example/CCLE_demo_S6.mini.bam
+/Users/user/Documents/GitHub/HCMM_CNVs_wrapper/Toy_example/CCLE_demo_S7.mini.bam
+/Users/user/Documents/GitHub/HCMM_CNVs_wrapper/Toy_example/CCLE_demo_S8.mini.bam
+/Users/user/Documents/GitHub/HCMM_CNVs_wrapper/Toy_example/CCLE_demo_S9.mini.bam


### PR DESCRIPTION
Closes issue #1  

Edited preprocessing function so that the tool accepts a `.txt` file containing paths to bams as input, rather than a folder with all the bams in it.  