### PR TITLE
delete .RData files

### DIFF
--- a/HCMM_CNVs_wrapper.R
+++ b/HCMM_CNVs_wrapper.R
@@ -153,3 +153,6 @@ if(chr != "all"){
   }
 }
 
+# Clean up intermediate files
+sapply(list.files(pattern = ".RData"), unlink)
+


### PR DESCRIPTION
Closes #5 
Delete intermediate `.RData` files produced.  These files will not be used again.  Warn user that any .RData files in that directory will be deleted